### PR TITLE
Increase retrieved document count

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -135,7 +135,7 @@ def initialize_retriever():
     db = Chroma.from_documents(splitted_docs, embedding=embeddings)
 
     # ベクターストアを検索するRetrieverの作成
-    st.session_state.retriever = db.as_retriever(search_kwargs={"k": 3})
+    st.session_state.retriever = db.as_retriever(search_kwargs={"k": 5})
 
 
 def initialize_session_state():


### PR DESCRIPTION
## Summary
- Expand vector store retrieval to return five documents for prompt context

## Testing
- `python -m py_compile initialize.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb910e68d08325b0ddbec8c06ff5d8