### PR TITLE
feat: display PDF page numbers

### DIFF
--- a/components.py
+++ b/components.py
@@ -88,7 +88,10 @@ def display_conversation_log():
                         icon = utils.get_source_icon(message['content']['main_file_path'])
                         # 参照元ドキュメントのページ番号が取得できた場合にのみ、ページ番号を表示
                         if "main_page_number" in message["content"]:
-                            st.success(f"{message['content']['main_file_path']}", icon=icon)
+                            st.success(
+                                f"{message['content']['main_file_path']}（{message['content']['main_page_number']}ページ）",
+                                icon=icon,
+                            )
                         else:
                             st.success(f"{message['content']['main_file_path']}", icon=icon)
                         
@@ -105,7 +108,10 @@ def display_conversation_log():
                                 icon = utils.get_source_icon(sub_choice['source'])
                                 # 参照元ドキュメントのページ番号が取得できた場合にのみ、ページ番号を表示
                                 if "page_number" in sub_choice:
-                                    st.info(f"{sub_choice['source']}", icon=icon)
+                                    st.info(
+                                        f"{sub_choice['source']}（{sub_choice['page_number']}ページ）",
+                                        icon=icon,
+                                    )
                                 else:
                                     st.info(f"{sub_choice['source']}", icon=icon)
                     # ファイルのありかの情報が取得できなかった場合、LLMからの回答のみ表示
@@ -156,11 +162,17 @@ def display_search_llm_response(llm_response):
         # 参照元のありかに応じて、適したアイコンを取得
         icon = utils.get_source_icon(main_file_path)
         # ページ番号が取得できた場合のみ、ページ番号を表示（ドキュメントによっては取得できない場合がある）
-        if "page" in llm_response["context"][0].metadata:
+        if (
+            "page" in llm_response["context"][0].metadata
+            and main_file_path.lower().endswith(".pdf")
+        ):
             # ページ番号を取得
             main_page_number = llm_response["context"][0].metadata["page"]
             # 「メインドキュメントのファイルパス」と「ページ番号」を表示
-            st.success(f"{main_file_path}", icon=icon)
+            st.success(
+                f"{main_file_path}（{main_page_number}ページ）",
+                icon=icon,
+            )
         else:
             # 「メインドキュメントのファイルパス」を表示
             st.success(f"{main_file_path}", icon=icon)
@@ -191,7 +203,7 @@ def display_search_llm_response(llm_response):
             duplicate_check_list.append(sub_file_path)
             
             # ページ番号が取得できない場合のための分岐処理
-            if "page" in document.metadata:
+            if "page" in document.metadata and sub_file_path.lower().endswith(".pdf"):
                 # ページ番号を取得
                 sub_page_number = document.metadata["page"]
                 # 「サブドキュメントのファイルパス」と「ページ番号」の辞書を作成
@@ -216,7 +228,10 @@ def display_search_llm_response(llm_response):
                 # ページ番号が取得できない場合のための分岐処理
                 if "page_number" in sub_choice:
                     # 「サブドキュメントのファイルパス」と「ページ番号」を表示
-                    st.info(f"{sub_choice['source']}", icon=icon)
+                    st.info(
+                        f"{sub_choice['source']}（{sub_choice['page_number']}ページ）",
+                        icon=icon,
+                    )
                 else:
                     # 「サブドキュメントのファイルパス」を表示
                     st.info(f"{sub_choice['source']}", icon=icon)
@@ -233,7 +248,10 @@ def display_search_llm_response(llm_response):
         content["main_message"] = main_message
         content["main_file_path"] = main_file_path
         # メインドキュメントのページ番号は、取得できた場合にのみ追加
-        if "page" in llm_response["context"][0].metadata:
+        if (
+            "page" in llm_response["context"][0].metadata
+            and main_file_path.lower().endswith(".pdf")
+        ):
             content["main_page_number"] = main_page_number
         # サブドキュメントの情報は、取得できた場合にのみ追加
         if sub_choices:
@@ -291,12 +309,12 @@ def display_contact_llm_response(llm_response):
             if file_path in file_path_list:
                 continue
 
-            # ページ番号が取得できた場合のみ、ページ番号を表示（ドキュメントによっては取得できない場合がある）
-            if "page" in document.metadata:
+            # ページ番号が取得できた場合のみ、ページ番号を表示（PDFのみ）
+            if "page" in document.metadata and file_path.lower().endswith(".pdf"):
                 # ページ番号を取得
                 page_number = document.metadata["page"]
-                # 「ファイルパス」と「ページ番号」
-                file_info = f"{file_path}"
+                # 「ファイルパス」と「ページ番号」を結合
+                file_info = f"{file_path}（{page_number}ページ）"
             else:
                 # 「ファイルパス」のみ
                 file_info = f"{file_path}"


### PR DESCRIPTION
## Summary
- show PDF page numbers in search and inquiry results
- persist page numbers in chat log for redisplay

## Testing
- `python -m py_compile components.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb91eff4e48325a84019b8e6ecc68c