### PR TITLE
Add PDF page numbers to search results

### DIFF
--- a/components.py
+++ b/components.py
@@ -85,12 +85,19 @@ def display_conversation_log():
                         st.markdown(message["content"]["main_message"])
 
                         # 参照元のありかに応じて、適したアイコンを取得
-                        icon = utils.get_source_icon(message['content']['main_file_path'])
-                        # 参照元ドキュメントのページ番号が取得できた場合にのみ、ページ番号を表示
-                        if "main_page_number" in message["content"]:
-                            st.success(f"{message['content']['main_file_path']}", icon=icon)
+                        main_path = message['content']['main_file_path']
+                        icon = utils.get_source_icon(main_path)
+                        # 参照元ドキュメントがPDFかつページ番号が取得できた場合のみ、ページ番号を表示
+                        if (
+                            "main_page_number" in message["content"]
+                            and main_path.lower().endswith(".pdf")
+                        ):
+                            st.success(
+                                f"{main_path}（{message['content']['main_page_number']}ページ）",
+                                icon=icon,
+                            )
                         else:
-                            st.success(f"{message['content']['main_file_path']}", icon=icon)
+                            st.success(f"{main_path}", icon=icon)
                         
                         # ==========================================
                         # ユーザー入力値と関連性が高いサブドキュメントのありかを表示
@@ -102,12 +109,19 @@ def display_conversation_log():
                             # サブドキュメントのありかを一覧表示
                             for sub_choice in message["content"]["sub_choices"]:
                                 # 参照元のありかに応じて、適したアイコンを取得
-                                icon = utils.get_source_icon(sub_choice['source'])
-                                # 参照元ドキュメントのページ番号が取得できた場合にのみ、ページ番号を表示
-                                if "page_number" in sub_choice:
-                                    st.info(f"{sub_choice['source']}", icon=icon)
+                                sub_path = sub_choice['source']
+                                icon = utils.get_source_icon(sub_path)
+                                # PDFファイルでページ番号が取得できた場合のみ、ページ番号を表示
+                                if (
+                                    "page_number" in sub_choice
+                                    and sub_path.lower().endswith(".pdf")
+                                ):
+                                    st.info(
+                                        f"{sub_path}（{sub_choice['page_number']}ページ）",
+                                        icon=icon,
+                                    )
                                 else:
-                                    st.info(f"{sub_choice['source']}", icon=icon)
+                                    st.info(f"{sub_path}", icon=icon)
                     # ファイルのありかの情報が取得できなかった場合、LLMからの回答のみ表示
                     else:
                         st.markdown(message["content"]["answer"])
@@ -155,12 +169,18 @@ def display_search_llm_response(llm_response):
         
         # 参照元のありかに応じて、適したアイコンを取得
         icon = utils.get_source_icon(main_file_path)
-        # ページ番号が取得できた場合のみ、ページ番号を表示（ドキュメントによっては取得できない場合がある）
-        if "page" in llm_response["context"][0].metadata:
-            # ページ番号を取得
-            main_page_number = llm_response["context"][0].metadata["page"]
+        # ページ番号が取得でき、かつPDFファイルの場合のみページ番号を表示
+        if (
+            "page" in llm_response["context"][0].metadata
+            and main_file_path.lower().endswith(".pdf")
+        ):
+            # ページ番号を取得（0始まりのため1を加算）
+            main_page_number = llm_response["context"][0].metadata["page"] + 1
             # 「メインドキュメントのファイルパス」と「ページ番号」を表示
-            st.success(f"{main_file_path}", icon=icon)
+            st.success(
+                f"{main_file_path}（{main_page_number}ページ）",
+                icon=icon,
+            )
         else:
             # 「メインドキュメントのファイルパス」を表示
             st.success(f"{main_file_path}", icon=icon)
@@ -191,9 +211,12 @@ def display_search_llm_response(llm_response):
             duplicate_check_list.append(sub_file_path)
             
             # ページ番号が取得できない場合のための分岐処理
-            if "page" in document.metadata:
-                # ページ番号を取得
-                sub_page_number = document.metadata["page"]
+            if (
+                "page" in document.metadata
+                and sub_file_path.lower().endswith(".pdf")
+            ):
+                # ページ番号を取得（0始まりのため1を加算）
+                sub_page_number = document.metadata["page"] + 1
                 # 「サブドキュメントのファイルパス」と「ページ番号」の辞書を作成
                 sub_choice = {"source": sub_file_path, "page_number": sub_page_number}
             else:
@@ -212,14 +235,21 @@ def display_search_llm_response(llm_response):
             # サブドキュメントに対してのループ処理
             for sub_choice in sub_choices:
                 # 参照元のありかに応じて、適したアイコンを取得
-                icon = utils.get_source_icon(sub_choice['source'])
-                # ページ番号が取得できない場合のための分岐処理
-                if "page_number" in sub_choice:
+                sub_path = sub_choice['source']
+                icon = utils.get_source_icon(sub_path)
+                # ページ番号が取得でき、かつPDFファイルの場合の分岐処理
+                if (
+                    "page_number" in sub_choice
+                    and sub_path.lower().endswith(".pdf")
+                ):
                     # 「サブドキュメントのファイルパス」と「ページ番号」を表示
-                    st.info(f"{sub_choice['source']}", icon=icon)
+                    st.info(
+                        f"{sub_path}（{sub_choice['page_number']}ページ）",
+                        icon=icon,
+                    )
                 else:
                     # 「サブドキュメントのファイルパス」を表示
-                    st.info(f"{sub_choice['source']}", icon=icon)
+                    st.info(f"{sub_path}", icon=icon)
         
         # 表示用の会話ログに格納するためのデータを用意
         # - 「mode」: モード（「社内文書検索」or「社内問い合わせ」）
@@ -233,7 +263,10 @@ def display_search_llm_response(llm_response):
         content["main_message"] = main_message
         content["main_file_path"] = main_file_path
         # メインドキュメントのページ番号は、取得できた場合にのみ追加
-        if "page" in llm_response["context"][0].metadata:
+        if (
+            "page" in llm_response["context"][0].metadata
+            and main_file_path.lower().endswith(".pdf")
+        ):
             content["main_page_number"] = main_page_number
         # サブドキュメントの情報は、取得できた場合にのみ追加
         if sub_choices:
@@ -292,11 +325,14 @@ def display_contact_llm_response(llm_response):
                 continue
 
             # ページ番号が取得できた場合のみ、ページ番号を表示（ドキュメントによっては取得できない場合がある）
-            if "page" in document.metadata:
-                # ページ番号を取得
-                page_number = document.metadata["page"]
+            if (
+                "page" in document.metadata
+                and file_path.lower().endswith(".pdf")
+            ):
+                # ページ番号を取得（0始まりのため1を加算）
+                page_number = document.metadata["page"] + 1
                 # 「ファイルパス」と「ページ番号」
-                file_info = f"{file_path}"
+                file_info = f"{file_path}（{page_number}ページ）"
             else:
                 # 「ファイルパス」のみ
                 file_info = f"{file_path}"


### PR DESCRIPTION
## Summary
- show page numbers for PDF documents in search mode results
- include PDF page numbers in inquiry mode reference list

## Testing
- `python -m py_compile components.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb91fe24e88325bddf40837e3bc55b