### PR TITLE
feat: support txt documents in data loading

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -50,7 +50,8 @@ RAG_TOP_FOLDER_PATH = "./data"
 SUPPORTED_EXTENSIONS = {
     ".pdf": PyMuPDFLoader,
     ".docx": Docx2txtLoader,
-    ".csv": lambda path: CSVLoader(path, encoding="utf-8")
+    ".csv": lambda path: CSVLoader(path, encoding="utf-8"),
+    ".txt": lambda path: TextLoader(path, encoding="utf-8"),
 }
 WEB_URL_LOAD_TARGETS = [
     "https://generative-ai.web-camp.io/"


### PR DESCRIPTION
## Summary
- allow text files to be loaded into the vector store by treating `.txt` as a supported extension

## Testing
- `python - <<'PY'
import initialize, constants as ct
ct.WEB_URL_LOAD_TARGETS = []
all_docs = initialize.load_data_sources()
print('Total docs after change:', len(all_docs))
print('Any txt documents?', any(doc.metadata['source'].endswith('.txt') for doc in all_docs))
for doc in all_docs:
    if doc.metadata['source'].endswith('.txt'):
        print('Loaded txt file:', doc.metadata['source'])
PY`
- `python -m py_compile constants.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb920d784c832585f380ffbb22a66e